### PR TITLE
Release 3.3.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slr-client",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "private": true,
   "description": "Client for Lista Robinson Service",
   "author": "Adigital",

--- a/src/config.js
+++ b/src/config.js
@@ -2,7 +2,7 @@
   Defaults for SLR-Client
  */
 
-const hashesPerRequest = 20 // As SLR API documentation indicates
+const hashesPerRequest = 60 // As SLR API documentation indicates
 const maxRps = window.electronFs ? 2000 : 1000
 const autoParallel = Math.ceil(maxRps/hashesPerRequest) // Math.ceil prevents autoParallel === 0
 const maxParallel = autoParallel < 50 ? autoParallel : 50 // Prevent too many threads


### PR DESCRIPTION
- Hashes per request increased to 60 as SLR API documentation update.